### PR TITLE
run dependabot twice a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,8 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "cron"
+      cronjob: "0 5 9,23 * *"
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
The old setup checked for updates every day and auto-merged them the same day. That didn't work well for fast-moving dependencies because the same package could be bumped on consecutive days as new eligible releases kept appearing.